### PR TITLE
Add/mitomen/58 add planview

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -41,8 +41,8 @@ jobs:
       - name: run ESLint
         run: npm run lint
         working-directory: ${{ env.TAURI_APP }}
-
-			# Jest
+		
+	  # Jest
       - name: run Jest
         run: npm run test
         working-directory: ${{ env.TAURI_APP }}

--- a/CharaDo/package-lock.json
+++ b/CharaDo/package-lock.json
@@ -83,6 +83,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2489,6 +2490,7 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2499,6 +2501,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2582,6 +2585,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -2833,6 +2837,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3348,6 +3353,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4219,6 +4225,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5713,6 +5720,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6330,6 +6338,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7180,6 +7189,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7468,6 +7478,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8394,6 +8405,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8526,6 +8538,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8691,6 +8704,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8839,6 +8853,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8932,6 +8947,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9185,6 +9201,7 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/CharaDo/src-tauri/src/repository/store.rs
+++ b/CharaDo/src-tauri/src/repository/store.rs
@@ -148,15 +148,25 @@ use obfstr::obfstr;
 // 開発用
 pub fn get_store_info_dev() -> Result<Vec<StoreAddOn>, UserError> {
   Ok(vec![
-		StoreAddOn {
-      id: obfstr!(env!("ADDON_ID_MOTION_EXPANSION")).to_string(),
-      title: "ADDON_ID_MOTION_EXPANSION".to_string(),
-      is_owned: true,
-    },
-		StoreAddOn {
-      id: obfstr!(env!("ADDON_ID_CUSTOM_FRAME_1")).to_string(),
-      title: "ADDON_ID_CUSTOM_FRAME_1".to_string(),
-      is_owned: true,
-    },
+        StoreAddOn {
+            id: obfstr!(env!("ADDON_ID_MOTION_EXPANSION")).to_string(),
+            title: "ADDON_ID_MOTION_EXPANSION".to_string(),
+            is_owned: true,
+        },
+        StoreAddOn {
+            id: obfstr!(env!("ADDON_ID_CUSTOM_FRAME_1")).to_string(),
+            title: "ADDON_ID_CUSTOM_FRAME_1".to_string(),
+            is_owned: true,
+        },
+        StoreAddOn {
+            id: obfstr!(env!("ADDON_ID_CUSTOM_FRAME_2")).to_string(),
+            title: "ADDON_ID_CUSTOM_FRAME_2".to_string(),
+            is_owned: true,
+        },
+        StoreAddOn {
+            id: obfstr!(env!("ADDON_ID_CUSTOM_FRAME_4")).to_string(),
+            title: "ADDON_ID_CUSTOM_FRAME_4".to_string(),
+            is_owned: true,
+        },
 	])
 }

--- a/CharaDo/src-tauri/tauri.conf.json
+++ b/CharaDo/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "charado",
-	"version": "0.1.0",
+	"version": "0.2.1",
 	"identifier": "com.cfeel.charado",
 	"build": {
 		"beforeDevCommand": "npm run dev",

--- a/CharaDo/src/views/DebugView.tsx
+++ b/CharaDo/src/views/DebugView.tsx
@@ -3,103 +3,63 @@ import { info } from "@tauri-apps/plugin-log";
 import { useState } from "react";
 
 const DebugView: React.FC = () => {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const [appInfo, setAppInfo] = useState<any>(null);
-	const [loading, setLoading] = useState(false);
-
-	async function testLog() {
-		await info("DebugView: test button clicked");
-	}
+	const [addons, setAddons] = useState<any>(null); // アドオン専用のステート
+	const [loadingInfo, setLoadingInfo] = useState(false); // アプリ情報用
+	const [loadingAddons, setLoadingAddons] = useState(false); // アドオン用
 
 	async function getStoreInfo() {
-		setLoading(true);
+		setLoadingInfo(true);
 		try {
-			// 型を any にして生のレスポンスを受け取る
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const data = await invoke<any>("get_store_info");
 			setAppInfo(data);
 			await info("DebugView: store app info fetched");
-			console.log("App Info:", data);
 		} catch (error) {
-			// 詳細を全部出力する（DevTools と端末）
-			console.error("Error fetching app info (raw):", error);
-			console.dir(error);
-			try {
-				// Error オブジェクトの非列挙プロパティも含めて文字列化
-				const snap = JSON.stringify(error, Object.getOwnPropertyNames(error));
-				console.log("Error JSON snapshot:", snap);
-			} catch (e) {
-				console.warn("stringify error failed:", e);
-			}
-			await info(`get_store_info error: ${String(error)}`);
+			console.error("Error fetching app info:", error);
 		} finally {
-			setLoading(false);
+			setLoadingInfo(false);
 		}
 	}
 
 	async function getStoreAddons() {
-		setLoading(true);
+		setLoadingAddons(true);
 		try {
-			// 型を any にして生のレスポンスを受け取る
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const data = await invoke<any>("get_store_addons");
-			setAppInfo(data);
+	        setAddons(data); // appInfo とは別の場所に保存
 			await info("DebugView: store addons fetched");
-			console.log("Store AddOns:", data);
 		} catch (error) {
-			// 詳細を全部出力する（DevTools と端末）
-			console.error("Error fetching store addons (raw):", error);
-			console.dir(error);
-			try {
-				// Error オブジェクトの非列挙プロパティも含めて文字列化
-				const snap = JSON.stringify(error, Object.getOwnPropertyNames(error));
-				console.log("Error JSON snapshot:", snap);
-			} catch (e) {
-				console.warn("stringify error failed:", e);
-			}
-			await info(`get_store_addons error: ${String(error)}`);
+			console.error("Error fetching store addons:", error);
 		} finally {
-			setLoading(false);
+			setLoadingAddons(false);
 		}
 	}
 
 	return (
 		<div>
 			<h2>Debug View</h2>
-			<video
-				src="http://assets.localhost/tumugi/達成時.webm"
-				controls
-				width="300"
-			/>
-			<img src="http://assets.localhost/tumugi/thumbnail.png" alt="紬" />
 			<div style={{ display: "flex", gap: "8px", marginBottom: "16px" }}>
-				<button onClick={testLog}>
-					Test Log
-				</button><br></br>
-				<button onClick={getStoreInfo} disabled={loading}>
-					{loading ? "Loading..." : "Get Store App Info"}
-				</button><br></br>
-				<button onClick={getStoreAddons} disabled={loading}>
-					{loading ? "Loading..." : "Get Store AddOns"}
-				</button><br></br>
+				<button onClick={getStoreInfo} disabled={loadingInfo}>
+					{loadingInfo ? "Loading Info..." : "Get Store App Info"}
+				</button>
+				<button onClick={getStoreAddons} disabled={loadingAddons}>
+					{loadingAddons ? "Loading AddOns..." : "Get Store AddOns"}
+				</button>
 			</div>
-
-			{appInfo && (
-				<div style={{ textAlign: "left" }}>
-					<h3>Result:</h3>
-					<pre style={{
-						marginTop: 12,
-						padding: 8,
-						border: "1px solid #ccc",
-						borderRadius: 6,
-						backgroundColor: "#f5f5f5",
-						color: "#333",
-						overflowX: "auto"
-					}}>
+			{/* 結果を別々に表示 */}
+			<div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "10px" }}>
+				<div>
+					<h3>App Info:</h3>
+					<pre style={{ background: "#f5f5f5", padding: "8px" }}>
 						{JSON.stringify(appInfo, null, 2)}
 					</pre>
 				</div>
-			)}
+				<div>
+					<h3>Store AddOns:</h3>
+					<pre style={{ background: "#f5f5f5", padding: "8px" }}>
+						{JSON.stringify(addons, null, 2)}
+					</pre>
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/CharaDo/src/views/PlanView.tsx
+++ b/CharaDo/src/views/PlanView.tsx
@@ -40,8 +40,8 @@ export const PlanView: React.FC = () => {
 	  	  	  return {
 	  	  	  	  display: "7",
 	  	  	  	  target: null,
-	  	  	  	  btnText: "最大アップグレード済み",
-	  	  	  	  btnColor: "bg-black",
+	  	  	  	  btnText: "購入不可",
+	  	  	  	  btnColor: "bg-gray-400",
 	  	  	  	  disabled: true,
 	  	  	  	  price: "---"
 	  	  	  };

--- a/CharaDo/src/views/PlanView.tsx
+++ b/CharaDo/src/views/PlanView.tsx
@@ -1,24 +1,270 @@
-import React from "react";
-import { useAddons, AddonTypeLevelMap } from "@features/addons";
+import React, { useMemo, useEffect } from "react";
+import { useAddons } from "@features/addons";
+import { AddonType } from "@entities/store"; 
+
+const PRICES: Record<string, string> = {
+  DataExpansion: "500円",
+  MotionExpansion: "500円",
+  CustomFrameAdd1: "500円",
+  CustomFrameAdd2: "500円",
+  CustomFrameAdd4: "500円",
+  AllIn: "1000円",
+  Donate: "500円",
+};
 
 const PlanView: React.FC = () => {
-	const { addons, loading } = useAddons();
+  // addons が undefined/null の場合に備え、徹底的にガードを固める
+  const addonData = useAddons();
+  const addons = addonData?.addons || [];
+  const loading = addonData?.loading || false;
 
-	if (loading) {
-		return <div className="p-10 text-center text-gray-500">Loading addons...</div>;
-	}
+  // デバッグ用：現在の所持状況をコンソールで確認
+  useEffect(() => {
+    console.log("Owned Addons:", addons);
+  }, [addons]);
 
-	return (
-		<div>
-			<h1>PlanView</h1>
-			<p>所持しているアドオン</p>
-			<ul>
-				{addons.map((addon) => (
-					<li key={addon}>{AddonTypeLevelMap[addon]}</li>
-				))}
-			</ul>
-		</div>
-	);
+  // ローディング表示
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-[#FDF5E6]">
+        <div className="text-xl font-bold text-gray-400">読み込み中...</div>
+      </div>
+    );
+  }
+
+  // --- 判定ロジック ---
+  const safeAddons = Array.isArray(addons) ? addons : [];
+
+  // 基本パック
+  const hasData = safeAddons.includes("DataExpansion" as AddonType);
+  const hasMotion = safeAddons.includes("MotionExpansion" as AddonType);
+  const hasAllIn = safeAddons.includes("AllIn" as any);
+
+  // キャラカスタム枠の段階判定
+  const hasF1 = safeAddons.includes("CustomFrameAdd1" as AddonType);
+  const hasF2 = safeAddons.includes("CustomFrameAdd2" as AddonType);
+  const hasF4 = safeAddons.includes("CustomFrameAdd4" as AddonType);
+
+  // 仕様に基づいたキャラ枠カードの状態計算
+  const frameCard = (() => {
+    // 1枠&2枠&4枠 全て保持時
+    if (hasF1 && hasF2 && hasF4) {
+      return {
+        display: "7",
+        target: null,
+        btnText: "最大アップグレード済み",
+        btnColor: "bg-gray-400",
+        disabled: true
+      };
+    }
+    // 1枠&2枠 保持時
+    if (hasF1 && hasF2) {
+      return {
+        display: "3 → 7",
+        target: "CustomFrameAdd4" as AddonType,
+        btnText: "アップグレード",
+        btnColor: "bg-amber-400",
+        disabled: false
+      };
+    }
+    // 1枠のみ保持時
+    if (hasF1) {
+      return {
+        display: "1 → 3",
+        target: "CustomFrameAdd2" as AddonType,
+        btnText: "アップグレード",
+        btnColor: "bg-amber-400",
+        disabled: false
+      };
+    }
+    // 未保持時
+    return {
+      display: "0 → 1",
+      target: "CustomFrameAdd1" as AddonType,
+      btnText: "アップグレード",
+      btnColor: "bg-amber-400",
+      disabled: false
+    };
+  })();
+
+  // オールインパックの購入可否 (いずれかの拡張をバラで持っている、または既にオールイン所持なら不可)
+  const isAnyExpansionOwned = hasData || hasMotion || hasF1 || hasF2 || hasF4 || hasAllIn;
+  const canBuyAllIn = !isAnyExpansionOwned;
+
+  const handleBuy = (type: string | null) => {
+    if (!type) return;
+    console.log(`Steam決済リクエスト: ${type}`);
+    // ここに invoke("request_purchase", { addonType: type }) 等を記述
+  };
+
+  return (
+    <div className="p-8 bg-[#FDF5E6] min-h-screen font-sans text-gray-800">
+      <div className="flex items-center gap-4 mb-10">
+        <span className="text-3xl font-bold">💰</span>
+        <h2 className="text-3xl font-bold text-gray-800">全てのプラン</h2>
+      </div>
+
+      <div className="grid grid-cols-4 gap-6 items-start">
+        
+        {/* データ拡張パック id:60-10 */}
+        <PlanCard
+          title="データ拡張パック"
+          price={PRICES.DataExpansion}
+          limitations={["今月分のカレンダーのみ閲覧可能", "選択日のタスク情報を確認不可"]}
+          benefits={["先月以前のカレンダーが閲覧可能になります", "選択日のタスク情報が確認可能になります"]}
+          buttonText={hasData ? "購入済み" : "購入"}
+          buttonDisabled={hasData}
+          buttonColor={hasData ? "bg-gray-400" : "bg-amber-400"}
+          onBuy={() => handleBuy("DataExpansion")}
+        />
+
+        {/* モーション拡張パック id:60-20 */}
+        <PlanCard
+          title="モーション拡張パック"
+          price={PRICES.MotionExpansion}
+          limitations={["通常/登場/退場/追加/達成時", "モーション＆セリフ"]}
+          benefits={["全てのキャラクターのタッチモーションを開放", "セリフの編集が可能になります"]}
+          buttonText={hasMotion ? "購入済み" : "購入"}
+          buttonDisabled={hasMotion}
+          buttonColor={hasMotion ? "bg-gray-400" : "bg-amber-400"}
+          onBuy={() => handleBuy("MotionExpansion")}
+        />
+
+        {/* キャラカスタム枠 id:60-30 (段階遷移対応) */}
+        <PlanCard
+          title="キャラカスタム枠"
+          price={frameCard.target ? PRICES[frameCard.target] : "---"}
+          limitations={["カスタムキャラクターなし"]}
+          benefits={["カスタムキャラクターを追加可能", "各々のアニメーションを自由に設定可能"]}
+          buttonText={frameCard.btnText}
+          buttonDisabled={frameCard.disabled}
+          buttonColor={frameCard.btnColor}
+          footerContent={
+            <div className="text-2xl font-bold mt-2 text-center text-gray-700">
+              {frameCard.display}
+            </div>
+          }
+          onBuy={() => handleBuy(frameCard.target)}
+        />
+
+        {/* 右側カラム：パックと寄付 */}
+        <div className="flex flex-col gap-6">
+          {/* オールインパック id:60-40 */}
+          <div className="border-2 border-dashed border-gray-300 rounded-2xl p-6 bg-white hover:shadow-lg transition-all">
+            <h3 className="text-xl font-bold text-center text-gray-800">オールインパック</h3>
+            <p className="text-2xl font-bold text-right my-4 text-gray-700">{PRICES.AllIn}</p>
+            <div className="text-[11px] space-y-1 mb-4 text-gray-600">
+              <p>① データ拡張パック</p>
+              <p>② モーション拡張パック</p>
+              <p>③ キャラカスタム枠 +1</p>
+              <p className="mt-2 font-bold text-gray-800">ⓘ 全ての拡張機能をアンロックします</p>
+            </div>
+            <div className="flex flex-col items-center gap-2">
+              <button
+                disabled={!canBuyAllIn}
+                onClick={() => handleBuy("AllIn")}
+                className={`w-full py-2 rounded-full font-bold shadow-sm transition-all text-white ${
+                  !canBuyAllIn ? "bg-gray-400 cursor-not-allowed" : "bg-amber-400 hover:bg-amber-500"
+                }`}
+              >
+                {hasAllIn ? "購入済み" : !canBuyAllIn ? "購入不可" : "購入"}
+              </button>
+              <span className="text-[10px] text-gray-400 underline cursor-pointer hover:text-gray-600">ⓘ 詳細はこちら</span>
+            </div>
+          </div>
+
+          {/* 寄付 id:60-50 */}
+          <div className="border-2 border-dashed border-gray-300 rounded-2xl p-6 bg-white hover:shadow-lg transition-all">
+            <h3 className="text-xl font-bold text-center text-gray-800">寄付</h3>
+            <div className="flex justify-between items-end my-4">
+              <span className="text-4xl">🍙</span>
+              <p className="text-2xl font-bold text-gray-700">{PRICES.Donate}</p>
+            </div>
+            <div className="text-[10px] space-y-1 mb-4 text-gray-500 leading-tight">
+              <p>ⓘ CharaDoは、ユーザの協力の元に成り立つプロジェクトです。</p>
+              <p>ⓘ 新しい機能の開発、紬・ノアのごはん代に使われます。</p>
+              <p>ⓘ 寄付による直接的なメリットはございません。</p>
+            </div>
+            <div className="flex flex-col items-center gap-2">
+              <button 
+                onClick={() => handleBuy("Donate")}
+                className="w-full py-2 rounded-full font-bold bg-amber-400 hover:bg-amber-500 text-white shadow-sm transition-all"
+              >
+                寄付
+              </button>
+              <span className="text-[10px] text-gray-400 underline cursor-pointer hover:text-gray-600">ⓘ 詳細はこちら</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 };
+
+// 共通カードコンポーネント (Props型定義)
+interface PlanCardProps {
+  title: string;
+  price: string;
+  limitations: string[];
+  benefits: string[];
+  buttonText: string;
+  buttonDisabled: boolean;
+  buttonColor: string;
+  onBuy: () => void;
+  footerContent?: React.ReactNode;
+}
+
+const PlanCard: React.FC<PlanCardProps> = ({ 
+  title, 
+  price, 
+  limitations = [], 
+  benefits = [], 
+  buttonText, 
+  buttonDisabled, 
+  buttonColor,
+  onBuy, 
+  footerContent 
+}) => (
+  <div className="border-2 border-dashed border-gray-300 rounded-2xl p-6 flex flex-col h-full bg-white hover:shadow-lg transition-all">
+    <div className="flex-grow">
+      <h3 className="text-lg font-bold text-center mb-4 text-gray-800">{title}</h3>
+      <p className="text-2xl font-bold text-right mb-6 text-gray-700">{price}</p>
+      
+      <div className="space-y-2 text-left mb-6">
+        {limitations.map((text, i) => (
+          <p key={i} className="text-[11px] text-gray-400 flex gap-1 items-start leading-tight">
+            <span>ⓘ</span> <span>{text}</span>
+          </p>
+        ))}
+      </div>
+
+      <div className="text-gray-400 text-xl my-4 text-center leading-none">↓</div>
+
+      <div className="space-y-2 text-left mb-6">
+        {benefits.map((text, i) => (
+          <p key={i} className="text-[11px] text-gray-800 font-medium flex gap-1 items-start leading-tight">
+            <span>✓</span> <span>{text}</span>
+          </p>
+        ))}
+      </div>
+    </div>
+
+    <div className="flex flex-col items-center gap-2 mt-auto">
+      <button
+        onClick={onBuy}
+        disabled={buttonDisabled}
+        className={`w-full py-2 rounded-full font-bold shadow-sm transition-all text-white ${buttonColor} ${
+          buttonDisabled ? "cursor-not-allowed opacity-80" : "hover:brightness-105 shadow-md"
+        }`}
+      >
+        {buttonText}
+      </button>
+      <span className="text-[10px] text-gray-400 underline cursor-pointer hover:text-gray-600">
+        ⓘ 詳細はこちら
+      </span>
+      {footerContent}
+    </div>
+  </div>
+);
 
 export default PlanView;

--- a/CharaDo/src/views/PlanView.tsx
+++ b/CharaDo/src/views/PlanView.tsx
@@ -1,270 +1,271 @@
 import React, { useMemo, useEffect } from "react";
-import { useAddons } from "@features/addons";
-import { AddonType } from "@entities/store"; 
+import { useAddons, AddonTypeLevel } from "@features/addons";
 
+// 価格定義：AddonTypeの文字列をキーにする
 const PRICES: Record<string, string> = {
-  DataExpansion: "500円",
-  MotionExpansion: "500円",
-  CustomFrameAdd1: "500円",
-  CustomFrameAdd2: "500円",
-  CustomFrameAdd4: "500円",
-  AllIn: "1000円",
-  Donate: "500円",
+		  DataExpansion: "500円",
+		  MotionExpansion: "500円",
+		  CustomFrameAdd1: "500円",
+		  CustomFrameAdd2: "500円",
+		  CustomFrameAdd4: "500円",
+		  AllIn: "1000円",
+		  Donate: "500円",
 };
 
-const PlanView: React.FC = () => {
-  // addons が undefined/null の場合に備え、徹底的にガードを固める
-  const addonData = useAddons();
-  const addons = addonData?.addons || [];
-  const loading = addonData?.loading || false;
+export const PlanView: React.FC = () => {
+	  // 自作フック useAddons を使用
+	  const { addons = [], loading = false } = useAddons();
 
-  // デバッグ用：現在の所持状況をコンソールで確認
-  useEffect(() => {
-    console.log("Owned Addons:", addons);
-  }, [addons]);
+	  // デバッグ用ログ
+	  useEffect(() => {
+	  	  console.log("PlanView Addons:", addons);
+	  }, [addons]);
 
-  // ローディング表示
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen bg-[#FDF5E6]">
-        <div className="text-xl font-bold text-gray-400">読み込み中...</div>
-      </div>
-    );
-  }
+	  // --- 判定ロジック：Hooksは早期リターンの前に全て記述する (Reactルール遵守) ---
+	  const safeAddons = useMemo(() => (Array.isArray(addons) ? addons : []), [addons]);
 
-  // --- 判定ロジック ---
-  const safeAddons = Array.isArray(addons) ? addons : [];
+	  // 各アドオンの所持判定
+	  const hasData = useMemo(() => safeAddons.includes(AddonTypeLevel.DataExpansion), [safeAddons]);
+	  const hasMotion = useMemo(() => safeAddons.includes(AddonTypeLevel.MotionExpansion), [safeAddons]);
+	  const hasAllIn = useMemo(() => safeAddons.includes("AllIn" as any), [safeAddons]);
 
-  // 基本パック
-  const hasData = safeAddons.includes("DataExpansion" as AddonType);
-  const hasMotion = safeAddons.includes("MotionExpansion" as AddonType);
-  const hasAllIn = safeAddons.includes("AllIn" as any);
+	  const hasF1 = useMemo(() => safeAddons.includes(AddonTypeLevel.CustomFrameAdd1), [safeAddons]);
+	  const hasF2 = useMemo(() => safeAddons.includes(AddonTypeLevel.CustomFrameAdd2), [safeAddons]);
+	  const hasF4 = useMemo(() => safeAddons.includes(AddonTypeLevel.CustomFrameAdd4), [safeAddons]);
 
-  // キャラカスタム枠の段階判定
-  const hasF1 = safeAddons.includes("CustomFrameAdd1" as AddonType);
-  const hasF2 = safeAddons.includes("CustomFrameAdd2" as AddonType);
-  const hasF4 = safeAddons.includes("CustomFrameAdd4" as AddonType);
+	  // キャラ枠カードの状態計算 (仕様: 0->1, 1->3, 3->7, 7)
+	  const frameCard = useMemo(() => {
+	  	  // 1枠&2枠&4枠 全て保持時
+	  	  if (hasF1 && hasF2 && hasF4) {
+	  	  	  return {
+	  	  	  	  display: "7",
+	  	  	  	  target: null,
+	  	  	  	  btnText: "最大アップグレード済み",
+	  	  	  	  btnColor: "bg-black",
+	  	  	  	  disabled: true,
+	  	  	  	  price: "---"
+	  	  	  };
+	  	  }
+	  	  // 1枠&2枠 保持時 -> 次は4枠追加
+	  	  if (hasF1 && hasF2) {
+	  	  	  return {
+	  	  	  	  display: "3 → 7",
+	  	  	  	  target: AddonTypeLevel.CustomFrameAdd4,
+	  	  	  	  btnText: "アップグレード",
+	  	  	  	  btnColor: "bg-amber-400",
+	  	  	  	  disabled: false,
+	  	  	  	  price: PRICES.CustomFrameAdd4
+	  	  	  };
+	  	  }
+	  	  // 1枠保持時 -> 次は2枠追加
+	  	  if (hasF1) {
+	  	  	  return {
+	  	  	  	  display: "1 → 3",
+	  	  	  	  target: AddonTypeLevel.CustomFrameAdd2,
+	  	  	  	  btnText: "アップグレード",
+	  	  	  	  btnColor: "bg-amber-400",
+	  	  	  	  disabled: false,
+	  	  	  	  price: PRICES.CustomFrameAdd2
+	  	  	  };
+	  	  }
+	  	  // 未保持時 -> 次は1枠追加
+	  	  return {
+	  	  	  display: "0 → 1",
+	  	  	  target: AddonTypeLevel.CustomFrameAdd1,
+	  	  	  btnText: "アップグレード",
+	  	  	  btnColor: "bg-amber-400",
+	  	  	  disabled: false,
+	  	  	  price: PRICES.CustomFrameAdd1
+	  	  };
+	  }, [hasF1, hasF2, hasF4]);
 
-  // 仕様に基づいたキャラ枠カードの状態計算
-  const frameCard = (() => {
-    // 1枠&2枠&4枠 全て保持時
-    if (hasF1 && hasF2 && hasF4) {
-      return {
-        display: "7",
-        target: null,
-        btnText: "最大アップグレード済み",
-        btnColor: "bg-gray-400",
-        disabled: true
-      };
-    }
-    // 1枠&2枠 保持時
-    if (hasF1 && hasF2) {
-      return {
-        display: "3 → 7",
-        target: "CustomFrameAdd4" as AddonType,
-        btnText: "アップグレード",
-        btnColor: "bg-amber-400",
-        disabled: false
-      };
-    }
-    // 1枠のみ保持時
-    if (hasF1) {
-      return {
-        display: "1 → 3",
-        target: "CustomFrameAdd2" as AddonType,
-        btnText: "アップグレード",
-        btnColor: "bg-amber-400",
-        disabled: false
-      };
-    }
-    // 未保持時
-    return {
-      display: "0 → 1",
-      target: "CustomFrameAdd1" as AddonType,
-      btnText: "アップグレード",
-      btnColor: "bg-amber-400",
-      disabled: false
-    };
-  })();
+	  // オールインパック購入可否 (いずれかの拡張をバラで持っている、または既にオールイン所持なら不可)
+	  const canBuyAllIn = useMemo(() => {
+	  	  return !(hasData || hasMotion || hasF1 || hasF2 || hasF4 || hasAllIn);
+	  }, [hasData, hasMotion, hasF1, hasF2, hasF4, hasAllIn]);
 
-  // オールインパックの購入可否 (いずれかの拡張をバラで持っている、または既にオールイン所持なら不可)
-  const isAnyExpansionOwned = hasData || hasMotion || hasF1 || hasF2 || hasF4 || hasAllIn;
-  const canBuyAllIn = !isAnyExpansionOwned;
+	  // --- ローディング判定 (Hooksの後に記述) ---
+	  if (loading) {
+	  	  return (
+	  	  	  <div className="flex items-center justify-center min-h-screen bg-[#FDF5E6]">
+	  	  	  	  <div className="text-xl font-bold text-gray-400 font-sans">読み込み中...</div>
+	  	  	  </div>
+	  	  );
+	  }
 
-  const handleBuy = (type: string | null) => {
-    if (!type) return;
-    console.log(`Steam決済リクエスト: ${type}`);
-    // ここに invoke("request_purchase", { addonType: type }) 等を記述
-  };
+	  const handleBuy = (type: string | null) => {
+	  	  if (!type) return;
+	  	  console.log(`Steam購入リクエスト: ${type}`);
+	  	  // ここで api-client 等を通じて購入処理を呼ぶ
+	  };
 
-  return (
-    <div className="p-8 bg-[#FDF5E6] min-h-screen font-sans text-gray-800">
-      <div className="flex items-center gap-4 mb-10">
-        <span className="text-3xl font-bold">💰</span>
-        <h2 className="text-3xl font-bold text-gray-800">全てのプラン</h2>
-      </div>
+	  return (
+	  	  <div className="p-8 bg-[#FDF5E6] min-h-screen font-sans text-gray-800 overflow-auto">
+	  	  	  <div className="flex items-center gap-4 mb-10">
+	  	  	  	  <span className="text-3xl font-bold">💰</span>
+	  	  	  	  <h2 className="text-3xl font-bold">全てのプラン</h2>
+	  	  	  </div>
 
-      <div className="grid grid-cols-4 gap-6 items-start">
-        
-        {/* データ拡張パック id:60-10 */}
-        <PlanCard
-          title="データ拡張パック"
-          price={PRICES.DataExpansion}
-          limitations={["今月分のカレンダーのみ閲覧可能", "選択日のタスク情報を確認不可"]}
-          benefits={["先月以前のカレンダーが閲覧可能になります", "選択日のタスク情報が確認可能になります"]}
-          buttonText={hasData ? "購入済み" : "購入"}
-          buttonDisabled={hasData}
-          buttonColor={hasData ? "bg-gray-400" : "bg-amber-400"}
-          onBuy={() => handleBuy("DataExpansion")}
-        />
+	  	  	  <div className="grid grid-cols-4 gap-6 items-start">
+	  	  	  	  {/* データ拡張パック id:60-10 */}
+	  	  	  	  <PlanCard
+	  	  	  	  	  title="データ拡張パック"
+	  	  	  	  	  price={PRICES.DataExpansion}
+	  	  	  	  	  limitations={["今月分のカレンダーのみ閲覧可能", "選択日のタスク情報を確認不可"]}
+	  	  	  	  	  benefits={["先月以前のカレンダーが閲覧可能になります", "選択日のタスク情報が確認可能になります"]}
+	  	  	  	  	  buttonText={hasData ? "購入済み" : "購入"}
+	  	  	  	  	  buttonDisabled={hasData}
+	  	  	  	  	  buttonColor={hasData ? "bg-gray-400" : "bg-amber-400"}
+	  	  	  	  	  onBuy={() => handleBuy("DataExpansion")}
+	  	  	  	  />
 
-        {/* モーション拡張パック id:60-20 */}
-        <PlanCard
-          title="モーション拡張パック"
-          price={PRICES.MotionExpansion}
-          limitations={["通常/登場/退場/追加/達成時", "モーション＆セリフ"]}
-          benefits={["全てのキャラクターのタッチモーションを開放", "セリフの編集が可能になります"]}
-          buttonText={hasMotion ? "購入済み" : "購入"}
-          buttonDisabled={hasMotion}
-          buttonColor={hasMotion ? "bg-gray-400" : "bg-amber-400"}
-          onBuy={() => handleBuy("MotionExpansion")}
-        />
+	  	  	  	  {/* モーション拡張パック id:60-20 */}
+	  	  	  	  <PlanCard
+	  	  	  	  	  title="モーション拡張パック"
+	  	  	  	  	  price={PRICES.MotionExpansion}
+	  	  	  	  	  limitations={["通常/登場/退場/追加/達成時", "モーション＆セリフ"]}
+	  	  	  	  	  benefits={["全てのキャラクターのタッチモーションを開放", "セリフの編集が可能になります"]}
+	  	  	  	  	  buttonText={hasMotion ? "購入済み" : "購入"}
+	  	  	  	  	  buttonDisabled={hasMotion}
+	  	  	  	  	  buttonColor={hasMotion ? "bg-gray-400" : "bg-amber-400"}
+	  	  	  	  	  onBuy={() => handleBuy("MotionExpansion")}
+	  	  	  	  />
 
-        {/* キャラカスタム枠 id:60-30 (段階遷移対応) */}
-        <PlanCard
-          title="キャラカスタム枠"
-          price={frameCard.target ? PRICES[frameCard.target] : "---"}
-          limitations={["カスタムキャラクターなし"]}
-          benefits={["カスタムキャラクターを追加可能", "各々のアニメーションを自由に設定可能"]}
-          buttonText={frameCard.btnText}
-          buttonDisabled={frameCard.disabled}
-          buttonColor={frameCard.btnColor}
-          footerContent={
-            <div className="text-2xl font-bold mt-2 text-center text-gray-700">
-              {frameCard.display}
-            </div>
-          }
-          onBuy={() => handleBuy(frameCard.target)}
-        />
+	  	  	  	  {/* キャラカスタム枠 id:60-30 */}
+	  	  	  	  <PlanCard
+	  	  	  	  	  title="キャラカスタム枠"
+	  	  	  	  	  price={frameCard.price}
+	  	  	  	  	  limitations={["カスタムキャラクターなし"]}
+	  	  	  	  	  benefits={["カスタムキャラクターを追加可能", "各々のアニメーションを自由に設定可能"]}
+	  	  	  	  	  buttonText={frameCard.btnText}
+	  	  	  	  	  buttonDisabled={frameCard.disabled}
+	  	  	  	  	  buttonColor={frameCard.btnColor}
+	  	  	  	  	  footerContent={
+	  	  	  	  	  	  <div className="text-2xl font-bold mt-2 text-center text-gray-700">
+	  	  	  	  	  	  	  {frameCard.display}
+	  	  	  	  	  	  </div>
+	  	  	  	  	  }
+	  	  	  	  	  onBuy={() => handleBuy(frameCard.target)}
+	  	  	  	  />
 
-        {/* 右側カラム：パックと寄付 */}
-        <div className="flex flex-col gap-6">
-          {/* オールインパック id:60-40 */}
-          <div className="border-2 border-dashed border-gray-300 rounded-2xl p-6 bg-white hover:shadow-lg transition-all">
-            <h3 className="text-xl font-bold text-center text-gray-800">オールインパック</h3>
-            <p className="text-2xl font-bold text-right my-4 text-gray-700">{PRICES.AllIn}</p>
-            <div className="text-[11px] space-y-1 mb-4 text-gray-600">
-              <p>① データ拡張パック</p>
-              <p>② モーション拡張パック</p>
-              <p>③ キャラカスタム枠 +1</p>
-              <p className="mt-2 font-bold text-gray-800">ⓘ 全ての拡張機能をアンロックします</p>
-            </div>
-            <div className="flex flex-col items-center gap-2">
-              <button
-                disabled={!canBuyAllIn}
-                onClick={() => handleBuy("AllIn")}
-                className={`w-full py-2 rounded-full font-bold shadow-sm transition-all text-white ${
-                  !canBuyAllIn ? "bg-gray-400 cursor-not-allowed" : "bg-amber-400 hover:bg-amber-500"
-                }`}
-              >
-                {hasAllIn ? "購入済み" : !canBuyAllIn ? "購入不可" : "購入"}
-              </button>
-              <span className="text-[10px] text-gray-400 underline cursor-pointer hover:text-gray-600">ⓘ 詳細はこちら</span>
-            </div>
-          </div>
+	  	  	  	  {/* 右側：パックと寄付 */}
+	  	  	  	  <div className="flex flex-col gap-6">
+	  	  	  	  	  {/* オールインパック id:60-40 */}
+	  	  	  	  	  <div className="border-2 border-dashed border-gray-300 rounded-2xl p-6 bg-white hover:shadow-lg transition-all">
+	  	  	  	  	  	  <h3 className="text-xl font-bold text-center">オールインパック</h3>
+	  	  	  	  	  	  <p className="text-2xl font-bold text-right my-4">{PRICES.AllIn}</p>
+	  	  	  	  	  	  <div className="text-[11px] space-y-1 mb-4 text-gray-600">
+	  	  	  	  	  	  	  <p>① データ拡張パック</p>
+	  	  	  	  	  	  	  <p>② モーション拡張パック</p>
+	  	  	  	  	  	  	  <p>③ キャラカスタム枠 +1</p>
+	  	  	  	  	  	  	  <p className="mt-2 font-bold text-gray-800">ⓘ 全ての拡張機能をアンロックします</p>
+	  	  	  	  	  	  </div>
+	  	  	  	  	  	  <div className="flex flex-col items-center gap-2">
+	  	  	  	  	  	  	  <button
+	  	  	  	  	  	  	  	  disabled={!canBuyAllIn}
+	  	  	  	  	  	  	  	  onClick={() => handleBuy("AllIn")}
+	  	  	  	  	  	  	  	  className={`w-full py-2 rounded-full font-bold shadow-sm transition-all text-white ${
+	  	  	  	  	  	  	  	  	  !canBuyAllIn ? "bg-gray-400 cursor-not-allowed" : "bg-amber-400 hover:bg-amber-500"
+	  	  	  	  	  	  	  	  }`}
+	  	  	  	  	  	  	  >
+	  	  	  	  	  	  	  	  {hasAllIn ? "購入済み" : !canBuyAllIn ? "購入不可" : "購入"}
+	  	  	  	  	  	  	  </button>
+	  	  	  	  	  	  	  <span className="text-[10px] text-gray-400 underline cursor-pointer hover:text-gray-600">ⓘ 詳細はこちら</span>
+	  	  	  	  	  	  </div>
+	  	  	  	  	  </div>
 
-          {/* 寄付 id:60-50 */}
-          <div className="border-2 border-dashed border-gray-300 rounded-2xl p-6 bg-white hover:shadow-lg transition-all">
-            <h3 className="text-xl font-bold text-center text-gray-800">寄付</h3>
-            <div className="flex justify-between items-end my-4">
-              <span className="text-4xl">🍙</span>
-              <p className="text-2xl font-bold text-gray-700">{PRICES.Donate}</p>
-            </div>
-            <div className="text-[10px] space-y-1 mb-4 text-gray-500 leading-tight">
-              <p>ⓘ CharaDoは、ユーザの協力の元に成り立つプロジェクトです。</p>
-              <p>ⓘ 新しい機能の開発、紬・ノアのごはん代に使われます。</p>
-              <p>ⓘ 寄付による直接的なメリットはございません。</p>
-            </div>
-            <div className="flex flex-col items-center gap-2">
-              <button 
-                onClick={() => handleBuy("Donate")}
-                className="w-full py-2 rounded-full font-bold bg-amber-400 hover:bg-amber-500 text-white shadow-sm transition-all"
-              >
-                寄付
-              </button>
-              <span className="text-[10px] text-gray-400 underline cursor-pointer hover:text-gray-600">ⓘ 詳細はこちら</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+	  	  	  	  	  {/* 寄付 id:60-50 */}
+	  	  	  	  	  <div className="border-2 border-dashed border-gray-300 rounded-2xl p-6 bg-white hover:shadow-lg transition-all">
+	  	  	  	  	  	  <h3 className="text-xl font-bold text-center text-gray-800">寄付</h3>
+	  	  	  	  	  	  <div className="flex justify-between items-end my-4">
+	  	  	  	  	  	  	  <span className="text-4xl">🍙</span>
+	  	  	  	  	  	  	  <p className="text-2xl font-bold text-gray-700 font-sans">{PRICES.Donate}</p>
+	  	  	  	  	  	  </div>
+	  	  	  	  	  	  <div className="text-[10px] space-y-1 mb-4 text-gray-500 leading-tight">
+	  	  	  	  	  	  	  <p>ⓘ CharaDoは、ユーザの協力の元に成り立つプロジェクトです。</p>
+	  	  	  	  	  	  	  <p>ⓘ 紬・ノアのごはん代、新機能開発に使われます。</p>
+	  	  	  	  	  	  	  <p>ⓘ 寄付による直接的なメリットはございません。</p>
+	  	  	  	  	  	  </div>
+	  	  	  	  	  	  <div className="flex flex-col items-center gap-2">
+	  	  	  	  	  	  	  <button 
+	  	  	  	  	  	  	  	  onClick={() => handleBuy("Donate")}
+	  	  	  	  	  	  	  	  className="w-full py-2 rounded-full font-bold bg-amber-400 hover:bg-amber-500 text-white shadow-sm transition-all"
+	  	  	  	  	  	  	  >
+	  	  	  	  	  	  	  	  寄付
+	  	  	  	  	  	  	  </button>
+	  	  	  	  	  	  	  <span className="text-[10px] text-gray-400 underline cursor-pointer hover:text-gray-600">ⓘ 詳細はこちら</span>
+	  	  	  	  	  	  </div>
+	  	  	  	  	  </div>
+	  	  	  	  </div>
+	  	  	  </div>
+	  	  </div>
+	  );
 };
 
-// 共通カードコンポーネント (Props型定義)
+// サブコンポーネント (Props型定義)
 interface PlanCardProps {
-  title: string;
-  price: string;
-  limitations: string[];
-  benefits: string[];
-  buttonText: string;
-  buttonDisabled: boolean;
-  buttonColor: string;
-  onBuy: () => void;
-  footerContent?: React.ReactNode;
+	  title: string;
+	  price: string;
+	  limitations: string[];
+	  benefits: string[];
+	  buttonText: string;
+	  buttonDisabled: boolean;
+	  buttonColor: string;
+	  onBuy: () => void;
+	  footerContent?: React.ReactNode;
 }
 
 const PlanCard: React.FC<PlanCardProps> = ({ 
-  title, 
-  price, 
-  limitations = [], 
-  benefits = [], 
-  buttonText, 
-  buttonDisabled, 
-  buttonColor,
-  onBuy, 
-  footerContent 
+	  title, 
+	  price, 
+	  limitations = [], 
+	  benefits = [], 
+	  buttonText, 
+	  buttonDisabled, 
+	  buttonColor,
+	  onBuy, 
+	  footerContent 
 }) => (
-  <div className="border-2 border-dashed border-gray-300 rounded-2xl p-6 flex flex-col h-full bg-white hover:shadow-lg transition-all">
-    <div className="flex-grow">
-      <h3 className="text-lg font-bold text-center mb-4 text-gray-800">{title}</h3>
-      <p className="text-2xl font-bold text-right mb-6 text-gray-700">{price}</p>
-      
-      <div className="space-y-2 text-left mb-6">
-        {limitations.map((text, i) => (
-          <p key={i} className="text-[11px] text-gray-400 flex gap-1 items-start leading-tight">
-            <span>ⓘ</span> <span>{text}</span>
-          </p>
-        ))}
-      </div>
+	  <div className="border-2 border-dashed border-gray-300 rounded-2xl p-6 flex flex-col h-full bg-white hover:shadow-lg transition-all">
+	  	  <div className="flex-grow">
+	  	  	  <h3 className="text-lg font-bold text-center mb-4 text-gray-800 font-sans">{title}</h3>
+	  	  	  <p className="text-2xl font-bold text-right mb-6 text-gray-700 font-sans">{price}</p>
+	  	  	  
+	  	  	  <div className="space-y-2 text-left mb-6 font-sans">
+	  	  	  	  {limitations.map((text, i) => (
+	  	  	  	  	  <p key={i} className="text-[11px] text-gray-400 flex gap-1 items-start leading-tight font-sans">
+	  	  	  	  	  	  <span>ⓘ</span> <span>{text}</span>
+	  	  	  	  	  </p>
+	  	  	  	  ))}
+	  	  	  </div>
 
-      <div className="text-gray-400 text-xl my-4 text-center leading-none">↓</div>
+	  	  	  <div className="text-gray-400 text-xl my-4 text-center leading-none">↓</div>
 
-      <div className="space-y-2 text-left mb-6">
-        {benefits.map((text, i) => (
-          <p key={i} className="text-[11px] text-gray-800 font-medium flex gap-1 items-start leading-tight">
-            <span>✓</span> <span>{text}</span>
-          </p>
-        ))}
-      </div>
-    </div>
+	  	  	  <div className="space-y-2 text-left mb-6 font-sans">
+	  	  	  	  {benefits.map((text, i) => (
+	  	  	  	  	  <p key={i} className="text-[11px] text-gray-800 font-medium flex gap-1 items-start leading-tight font-sans">
+	  	  	  	  	  	  <span>✓</span> <span>{text}</span>
+	  	  	  	  	  </p>
+	  	  	  	  ))}
+	  	  	  </div>
+	  	  </div>
 
-    <div className="flex flex-col items-center gap-2 mt-auto">
-      <button
-        onClick={onBuy}
-        disabled={buttonDisabled}
-        className={`w-full py-2 rounded-full font-bold shadow-sm transition-all text-white ${buttonColor} ${
-          buttonDisabled ? "cursor-not-allowed opacity-80" : "hover:brightness-105 shadow-md"
-        }`}
-      >
-        {buttonText}
-      </button>
-      <span className="text-[10px] text-gray-400 underline cursor-pointer hover:text-gray-600">
-        ⓘ 詳細はこちら
-      </span>
-      {footerContent}
-    </div>
-  </div>
+	  	  <div className="flex flex-col items-center gap-2 mt-auto">
+	  	  	  <button
+	  	  	  	  onClick={onBuy}
+	  	  	  	  disabled={buttonDisabled}
+	  	  	  	  className={`w-full py-2 rounded-full font-bold shadow-sm transition-all text-white font-sans ${buttonColor} ${
+	  	  	  	  	  buttonDisabled ? "cursor-not-allowed opacity-80" : "hover:brightness-105 shadow-md"
+	  	  	  	  }`}
+	  	  	  >
+	  	  	  	  {buttonText}
+	  	  	  </button>
+	  	  	  <span className="text-[10px] text-gray-400 underline cursor-pointer hover:text-gray-600 transition-colors font-sans">
+	  	  	  	  ⓘ 詳細はこちら
+	  	  	  </span>
+	  	  	  {footerContent}
+	  	  </div>
+	  </div>
 );
 
 export default PlanView;


### PR DESCRIPTION
- プラン画面を画面例・仕様書通り（キャラクター枠除く、こちらで勝手に仕様を決めました）に作成(by Gemini 3.0)
  - 枠未保持：0->1
  - 1枠保持：1->3
  - 1枠&2枠：3->7
  - 1枠&2枠&4枠：7 ボタン灰色　購入不可
- プランの購入状況による動的な動作の確認はバックエンドにモックを追加して確認してください
<img width="2559" height="1365" alt="image" src="https://github.com/user-attachments/assets/31fc90b2-2c28-4896-9b4a-2f4569666169" />
